### PR TITLE
Fix: Real-Time Event Search API Change

### DIFF
--- a/source/PopNGo/PopNGo/PopNGo/Controllers/EventApiController.cs
+++ b/source/PopNGo/PopNGo/PopNGo/Controllers/EventApiController.cs
@@ -20,7 +20,6 @@ public class EventApiController : Controller
     private readonly IEventHistoryRepository _eventHistoryRepository;
     private readonly IPgUserRepository _pgUserRepository;
     private readonly UserManager<PopNGoUser> _userManager;
-<<<<<<< HEAD
     private readonly ITagRepository _tagRepository;
 
     public EventApiController(
@@ -31,17 +30,12 @@ public class EventApiController : Controller
         IConfiguration configuration,
         ITagRepository tagRepository
     )
-=======
-
-    public EventApiController(IEventHistoryRepository eventHistoryRepository, IPgUserRepository pgUserRepository, UserManager<PopNGoUser> userManager, ILogger<EventApiController> logger, IConfiguration configuration)
->>>>>>> main
     {
         _logger = logger;
         _configuration = configuration;
         _eventHistoryRepository = eventHistoryRepository;
         _pgUserRepository = pgUserRepository;
         _userManager = userManager;
-<<<<<<< HEAD
         _tagRepository = tagRepository;
 
     }
@@ -77,36 +71,5 @@ public class EventApiController : Controller
         }
 
         return true;
-=======
-
-    }
-
-    // GET: api/eventHistory
-    [HttpGet("eventHistory")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<Models.DTO.EventHistory>))]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public ActionResult<IEnumerable<Models.DTO.EventHistory>> GetUserEventHistory()
-    {
-        PopNGoUser user = _userManager.GetUserAsync(User).Result;
-        if (user == null)
-        {
-            return Unauthorized();
-        }
-
-        PgUser pgUser = _pgUserRepository.GetPgUserFromIdentityId(user.Id);
-        if (pgUser == null)
-        {
-            return Unauthorized();
-        }
-
-        List<Models.DTO.EventHistory> events = _eventHistoryRepository.GetEventHistory(pgUser.Id);
-        if (events == null || events.Count == 0)
-        {
-            return NotFound();
-        }
-
-        return events;
->>>>>>> main
     }
 }

--- a/source/PopNGo/PopNGo/PopNGo/DAL/Concrete/EventHistoryRepository.cs
+++ b/source/PopNGo/PopNGo/PopNGo/DAL/Concrete/EventHistoryRepository.cs
@@ -6,9 +6,9 @@ using PopNGo.Models.DTO;
 
 namespace PopNGo.DAL.Concrete
 {
-    public class EventHistoryRepository : Repository<EventHistory>, IEventHistoryRepository
+    public class EventHistoryRepository : Repository<Models.EventHistory>, IEventHistoryRepository
     {
-        private readonly DbSet<EventHistory> _eventHistories;
+        private readonly DbSet<Models.EventHistory> _eventHistories;
         private readonly DbSet<Models.Event> _events;
         public EventHistoryRepository(PopNGoDB context) : base(context)
         {
@@ -51,7 +51,7 @@ namespace PopNGo.DAL.Concrete
                 return;
             } else
             {
-                var newEventHistory = new EventHistory { UserId = userId, EventId = eventEntity.Id, ViewedDate = DateTime.UtcNow };
+                var newEventHistory = new Models.EventHistory { UserId = userId, EventId = eventEntity.Id, ViewedDate = DateTime.UtcNow };
 
                 try
                 {

--- a/source/PopNGo/PopNGo/PopNGo/Models/DTO/EventHistory.cs
+++ b/source/PopNGo/PopNGo/PopNGo/Models/DTO/EventHistory.cs
@@ -9,7 +9,7 @@ namespace PopNGo.Models.DTO
         public int Id { get; set; }
         public int UserId { get; set; }
         public DateTime ViewedDate { get; set; }
-        public string EventId { get; set; }
+        public int EventId { get; set; }
         public DateTime EventDate { get; set; }
         public string EventName { get; set; }
         public string EventDescription { get; set; }
@@ -29,10 +29,10 @@ namespace PopNGo.ExtensionMethods
                 UserId = eventHistory.UserId,
                 ViewedDate = eventHistory.ViewedDate,
                 EventId = eventHistory.EventId,
-                EventDate = eventHistory.EventDate,
-                EventDescription = eventHistory.EventDescription,
-                EventLocation = eventHistory.EventLocation,
-                EventName = eventHistory.EventName
+                // EventDate = eventHistory.EventDate,
+                // EventDescription = eventHistory.EventDescription,
+                // EventLocation = eventHistory.EventLocation,
+                // EventName = eventHistory.EventName
     };
         }
     }

--- a/source/PopNGo/PopNGo/PopNGo/Models/EventDetail.cs
+++ b/source/PopNGo/PopNGo/PopNGo/Models/EventDetail.cs
@@ -23,10 +23,7 @@ namespace PopNGo.Models
         public double Latitude { get; set; }
         public double Longitude { get; set; }
         public string Phone_Number { get; set; }
-<<<<<<< HEAD
         public List<string> EventTags { get; set; } = [];
-=======
->>>>>>> main
     }
 }
 

--- a/source/PopNGo/PopNGo/PopNGo/Program.cs
+++ b/source/PopNGo/PopNGo/PopNGo/Program.cs
@@ -44,8 +44,8 @@ public class Program
         //     Password = builder.Configuration["PopNGo:DBPassword"]
         // };
         // var identityConnectionString = identityConnection.ConnectionString;
-        // var identityConnectionString = builder.Configuration.GetConnectionString("IdentityConnection");
-        var identityConnectionString = builder.Configuration.GetConnectionString("IdentityConnectionAzure");
+        var identityConnectionString = builder.Configuration.GetConnectionString("IdentityConnection");
+        // var identityConnectionString = builder.Configuration.GetConnectionString("IdentityConnectionAzure");
         builder.Services.AddDbContext<ApplicationDbContext>(options => options
             .UseSqlServer(identityConnectionString)
             .UseLazyLoadingProxies());
@@ -56,8 +56,8 @@ public class Program
         //     Password = builder.Configuration["PopNGo:DBPassword"]
         // };
         // var serverConnectionString = serverConnection.ConnectionString;
-        // var serverConnectionString = builder.Configuration.GetConnectionString("ServerConnection");
-        var serverConnectionString = builder.Configuration.GetConnectionString("ServerConnectionAzure");
+        var serverConnectionString = builder.Configuration.GetConnectionString("ServerConnection");
+        // var serverConnectionString = builder.Configuration.GetConnectionString("ServerConnectionAzure");
         builder.Services.AddDbContext<PopNGoDB>(options => options
             .UseSqlServer(serverConnectionString)
             .UseLazyLoadingProxies());


### PR DESCRIPTION
To account for Real-Time Event Search's API change where the list of events from a search no longer has their venue data included, this alters the process to create each event by pulling the specific event's details from the second endpoint `/event-details?event_id`.

This introduced an issue with rate-limiting via the API due to the individual queries that were now needed. To fix this, each event query is delayed by 250ms from when it was asked for. To avoid an unnecessarily long delay in processing the search, the main API call now delays its return until the events that have had their details queried is equal to the events that were returned from the search. The increase in search time is now minimal, but exists.